### PR TITLE
 Implement parallel with future.apply instead of furrr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Suggests:
     crayon,
     digest,
     fable,
-    furrr,
+    future.apply,
     knitr,
     methods,
     pillar (>= 1.0.1),

--- a/R/model.R
+++ b/R/model.R
@@ -82,12 +82,14 @@ Check that specified model(s) are model definitions.", nm[which(!is_mdl)[1]]))
   }
   
   if(is_attached("package:future")){
-    require_package("furrr")
+    require_package("future.apply")
     eval_models <- function(models, lst_data){
-      out <- furrr::future_map2(
+      out <- future.apply::future_mapply(
         rep(lst_data, length(models)),
         rep(models, each = length(lst_data)),
-        estimate, .progress = isTRUE(getOption("dplyr.show_progress")) && interactive() && num_est > 1 && is.null(getOption("knitr.in.progress"))
+        FUN = estimate,
+        SIMPLIFY = FALSE,
+        future.globals = FALSE
       )
       unname(split(out, rep(seq_len(num_mdl), each = num_key)))
     }


### PR DESCRIPTION
Hello,

I'd like to suggest replacing the `furrr` dependency  by [`future.apply`](https://github.com/HenrikBengtsson/future.apply) for the following reasons: 

* actively developed whereas there were no commits on the `furrr` repository for one year.
* maintained by the author of the `future` package, therefore future-proof (pardon the pun).

Moreover, I noted better performances with `future.apply`. Here is a simple benchmark:
``` r
library(future)
plan('multiprocess')
packageVersion('future')
#> [1] '1.13.0'
packageVersion('future.apply')
#> [1] '1.3.0'
packageVersion('furrr')
#> [1] '0.1.0'

X <- replicate(2, rnorm(1e6)) 

microbenchmark::microbenchmark(times = 50,
  future.apply = {future.apply::future_mapply(X[,1], X[,2], FUN = sum,
                                              SIMPLIFY = FALSE,
                                              future.globals = FALSE)},
  furrr = {furrr::future_map2(X[,1], X[,2], sum,
                              .options = furrr::future_options(globals = FALSE))}
)
#> Unit: seconds
#>          expr      min       lq     mean   median       uq      max neval
#>  future.apply 1.045680 1.374698 1.562006 1.537473 1.681425 2.256295    50
#>         furrr 1.700373 2.124333 2.505822 2.406694 2.680991 4.179943    50
```

<sup>Created on 2019-10-05 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

<details>

<summary>Session info</summary>

``` r
devtools::session_info()
#> ─ Session info ──────────────────────────────────────────────────────────
#>  setting  value                       
#>  version  R version 3.6.0 (2019-04-26)
#>  os       macOS Mojave 10.14.6        
#>  system   x86_64, darwin15.6.0        
#>  ui       X11                         
#>  language (EN)                        
#>  collate  en_US.UTF-8                 
#>  ctype    en_US.UTF-8                 
#>  tz       Europe/Paris                
#>  date     2019-10-05                  
#> 
#> ─ Packages ──────────────────────────────────────────────────────────────
#>  package        * version date       lib source        
#>  assertthat       0.2.1   2019-03-21 [1] CRAN (R 3.6.0)
#>  backports        1.1.5   2019-10-02 [1] CRAN (R 3.6.0)
#>  callr            3.3.1   2019-07-18 [1] CRAN (R 3.6.0)
#>  cli              1.1.0   2019-03-19 [1] CRAN (R 3.6.0)
#>  codetools        0.2-16  2018-12-24 [6] CRAN (R 3.6.0)
#>  crayon           1.3.4   2017-09-16 [1] CRAN (R 3.6.0)
#>  desc             1.2.0   2018-05-01 [1] CRAN (R 3.6.0)
#>  devtools         2.0.2   2019-04-08 [1] CRAN (R 3.6.0)
#>  digest           0.6.21  2019-09-20 [1] CRAN (R 3.6.0)
#>  evaluate         0.14    2019-05-28 [1] CRAN (R 3.6.0)
#>  fs               1.3.1   2019-05-06 [1] CRAN (R 3.6.0)
#>  furrr            0.1.0   2018-05-16 [1] CRAN (R 3.6.0)
#>  future         * 1.13.0  2019-05-08 [1] CRAN (R 3.6.0)
#>  future.apply     1.3.0   2019-06-18 [1] CRAN (R 3.6.0)
#>  globals          0.12.4  2018-10-11 [1] CRAN (R 3.6.0)
#>  glue             1.3.1   2019-03-12 [1] CRAN (R 3.6.0)
#>  highr            0.8     2019-03-20 [1] CRAN (R 3.6.0)
#>  htmltools        0.3.6   2017-04-28 [1] CRAN (R 3.6.0)
#>  knitr            1.24    2019-08-08 [1] CRAN (R 3.6.0)
#>  listenv          0.7.0   2018-01-21 [1] CRAN (R 3.6.0)
#>  magrittr         1.5     2014-11-22 [1] CRAN (R 3.6.0)
#>  memoise          1.1.0   2017-04-21 [1] CRAN (R 3.6.0)
#>  microbenchmark   1.4-7   2019-09-24 [1] CRAN (R 3.6.0)
#>  pkgbuild         1.0.3   2019-03-20 [1] CRAN (R 3.5.2)
#>  pkgload          1.0.2   2018-10-29 [1] CRAN (R 3.6.0)
#>  prettyunits      1.0.2   2015-07-13 [1] CRAN (R 3.6.0)
#>  processx         3.4.1   2019-07-18 [1] CRAN (R 3.6.0)
#>  ps               1.3.0   2018-12-21 [1] CRAN (R 3.5.0)
#>  purrr            0.3.2   2019-03-15 [1] CRAN (R 3.6.0)
#>  R6               2.4.0   2019-02-14 [1] CRAN (R 3.6.0)
#>  Rcpp             1.0.2   2019-07-25 [1] CRAN (R 3.6.0)
#>  remotes          2.1.0   2019-06-24 [1] CRAN (R 3.6.0)
#>  rlang            0.4.0   2019-06-25 [1] CRAN (R 3.6.0)
#>  rmarkdown        1.15    2019-08-21 [1] CRAN (R 3.6.0)
#>  rprojroot        1.3-2   2018-01-03 [1] CRAN (R 3.6.0)
#>  sessioninfo      1.1.1   2018-11-05 [1] CRAN (R 3.6.0)
#>  stringi          1.4.3   2019-03-12 [1] CRAN (R 3.6.0)
#>  stringr          1.4.0   2019-02-10 [1] CRAN (R 3.6.0)
#>  testthat         2.2.1   2019-07-25 [1] CRAN (R 3.6.0)
#>  usethis          1.5.1   2019-07-04 [1] CRAN (R 3.6.0)
#>  withr            2.1.2   2018-03-15 [1] CRAN (R 3.6.0)
#>  xfun             0.9     2019-08-21 [1] CRAN (R 3.6.0)
#>  yaml             2.2.0   2018-07-25 [1] CRAN (R 3.6.0)
#> 
#> [1] /Users/jeanfrancois/RLibraryPATH=/usr/local/clang6/bin
#> [2] /usr/bin
#> [3] /bin
#> [4] /usr/sbin
#> [5] /sbin
#> [6] /Library/Frameworks/R.framework/Versions/3.6/Resources/library
```

</details>

The only disadvantage is that `future.apply` doesn't support progress bars. 
