### PR TITLE
Fix stream to return lst_mdl class instead of list

### DIFF
--- a/R/stream.R
+++ b/R/stream.R
@@ -24,7 +24,7 @@ stream.mdl_df <- function(object, new_data, ...){
     transmute(
       !!!key(object),
       !!sym(".model"),
-      .fit = map2(!!sym(".fit"), !!sym("new_data"), stream, ...)
+      .fit = structure(map2(!!sym(".fit"), !!sym("new_data"), stream, ...), class=c("lst_mdl", "list"))
     ) %>%
     spread(".model", ".fit") %>% 
     as_mable(key = key(object), models = object%@%"models")


### PR DESCRIPTION
Hi @mitchelloharawild,

I was trying to follow your slides for the fasster package, but, as you noted in of the issues, the API has changed a bit. So I tried to adapt the code to make it work.

The essence of the problem: after applying stream() to the original fit, I get a model which is structured differently, causing forecast() on the updated package to fail.

Here's the code:
```
elec_tr <- tsibbledata::vic_elec %>%
  filter(
    yearmonth(Time) == yearmonth("2012 Mar")
  ) %>% 
  mutate(WorkDay = wday(Time) %in% 2:6 & !Holiday)

elec_update <- tsibbledata::vic_elec %>%
  filter(
    yearmonth(Time) == yearmonth("2012 Apr")
  ) %>% 
  mutate(WorkDay = wday(Time) %in% 2:6 & !Holiday)

elec_exog <- tsibbledata::vic_elec %>%
  filter(
    yearmonth(Time) == yearmonth("2012 May")
  ) %>% 
  mutate(WorkDay = wday(Time) %in% 2:6 & !Holiday) %>%
  select(-Demand)

elec_fit <- elec_tr %>%
  model(
    fasster = fasster(Demand ~ 
      WorkDay %S% (trig(48, 16) + poly(1)) + Temperature + I(Temperature^2)
    )
  )

elec_fit
```
Out:
```
# A mable: 1 x 1
  fasster  
  <model>  
1 <FASSTER>
```

And after the stream() call:
`elec_fit %>% stream(elec_update)`
Out:
```
# A mable: 1 x 1
  fasster  
  <list>   
1 <FASSTER>
```

Notice <model> vs <list>. Naturally, forecast.list is not found. After debugging for quite some time I fixed like in this PR. The forecast() function works as intended now.

I'm not sure if it's well aligned with other libraries which depend on fabletools. This fixes the issue for fasster though.

I can work on this further if it's an ok solution, like add tests.

My env:
```
 [1] rlang_0.4.2           fable_0.1.0           tsibble_0.8.5        
 [4] lubridate_1.7.4       forcats_0.4.0         stringr_1.4.0        
 [7] dplyr_0.8.3           purrr_0.3.3           readr_1.3.1          
[10] tidyr_1.0.0           tibble_2.1.3          ggplot2_3.2.1        
[13] tidyverse_1.3.0       fasster_0.1.0.9100    fabletools_0.1.1.9000
```
