### PR TITLE
implement future.apply in forecast.mdl_df

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,9 @@ Authors@R:
              role = "ctb"),
       person(given = "George",
              family = "Athanasopoulos",
+             role = "ctb"),
+      person(given = "David",
+             family = "Holt",
              role = "ctb"))
 Description: Provides tools, helpers and data structures for
     developing models and time series functions for 'fable' and extension

--- a/NEWS.md
+++ b/NEWS.md
@@ -30,7 +30,8 @@
   allowing unbalanced hierarchies to be reconciled.
 * Produce unique names for unnamed features used with `features()` (#258).
 * Documentation improvements
-* Performance improvements
+* Performance improvements, including using `future.apply()` to parallelize 
+  `forecast()` when the `future` package is attached (#268).
 
 ## Breaking changes
 

--- a/R/forecast.R
+++ b/R/forecast.R
@@ -105,13 +105,38 @@ forecast.mdl_df <- function(object, new_data = NULL, h = NULL,
     object <- bind_new_data(object, new_data)
   }
   
-  # Evaluate forecasts
-  object <- dplyr::mutate_at(as_tibble(object), vars(!!!mdls),
-                             forecast, object[["new_data"]],
-                             h = h, point_forecast = point_forecast, ...,
-                             key_data = key_data(object))
+  object <- tidyr::pivot_longer(object, !!mdls, names_to = ".model", values_to = ".mdl")
   
-  object <- tidyr::pivot_longer(object, !!mdls, names_to = ".model", values_to = ".fc") 
+  # Evaluate forecasts
+  if(is_attached("package:future")){
+    require_package("future.apply")
+    
+    object[[".fc"]] <- future.apply::future_mapply(
+      FUN = forecast,
+      object[[".mdl"]],
+      MoreArgs = list(
+        h = h, 
+        point_forecast = point_forecast,
+        ...,
+        key_data = key_data(object)
+      ),
+      SIMPLIFY = FALSE,
+      future.globals = FALSE
+    )
+  }
+  else{
+    object[[".fc"]] <- mapply(
+      FUN = forecast,
+      object[[".mdl"]],
+      MoreArgs = list(
+        h = h, 
+        point_forecast = point_forecast,
+        ...,
+        key_data = key_data(object)
+      ),
+      SIMPLIFY = FALSE
+    )
+  }
   
   # Combine and re-construct fable
   fbl_attr <- attributes(object$.fc[[1]])


### PR DESCRIPTION
As promised. I'm happy to use something other than the `mapply` for the non-`future.apply` implementation. This addresses issue #268