### PR TITLE
Fix example documentation of model decomposition

### DIFF
--- a/R/model_decomposition.R
+++ b/R/model_decomposition.R
@@ -107,7 +107,7 @@ Please check that you have specified the decomposition models appropriately.")
 #'   components() %>% 
 #'   autoplot()
 #'   
-#' # Use an ARIMA model to seasonally adjusted data, and SNAIVE to season_year
+#' # Use an ETS model to seasonally adjusted data, and SNAIVE to season_year
 #' # Any model can be used, and seasonal components will default to use SNAIVE.
 #' my_dcmp_spec <- decomposition_model(
 #'   STL(log(Turnover) ~ season(window = Inf)),


### PR DESCRIPTION
`ETS` is used in the example instead of `ARIMA`.