### PR TITLE
Use ggdist::ramp_colours in ggdist > 3.3.1

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -318,9 +318,13 @@ build_fbl_layer <- function(object, data = NULL, level = c(80, 95),
     }
     # Apply ramped fill
     if (!is.null(data[["fill_ramp"]])) {
-      data$fill = mapply(function(color, amount){
-        (scales::seq_gradient_pal(attr(amount, "from") %||% "white", color))(amount %||% NA)
-      }, data$fill, data$fill_ramp)
+      if (utils::packageVersion("ggdist") > "3.3.1") {
+        data$fill <- ggdist::ramp_colours(data$fill, data$fill_ramp)
+      } else {
+        data$fill <- mapply(function(color, amount){
+          (scales::seq_gradient_pal(attr(amount, "from") %||% "white", color))(amount %||% NA)
+        }, data$fill, data$fill_ramp)
+      }
     }
     ggplot2::draw_key_rect(data, params, size)
   }


### PR DESCRIPTION
Hi @mitchelloharawild --- I am preparing to make a new release of {ggdist} this week, partly to fix some minor issues due to the new release of {ggplot2}. During revdep checks I found a minor issue in {fabletools}.

As I am sure you discovered, colour ramps produced by {ggdist} were previously just a list type with attributes, and the method for applying them was not exported. The new version of {ggdist} now uses a proper datatype to represent partial colour ramps produced by the `colour_ramp` and `fill_ramp` scales, and exports a function, `ggdist::ramp_colours()`, for applying them. As a result, the old approach for translating colour ramps into colour no longer works and needs to be updated here, which this PR does.